### PR TITLE
Implement case opening with drop table

### DIFF
--- a/controllers/caseController.js
+++ b/controllers/caseController.js
@@ -1,3 +1,6 @@
+const User = require('../models/User');
+const getRandomSkin = require('../utils/dropTable');
+
 const CASE_PRICE = 250;
 
 exports.openCase = async (req, res) => {

--- a/utils/dropTable.js
+++ b/utils/dropTable.js
@@ -1,0 +1,30 @@
+const skins = [
+  { name: 'USP-S | Dark Water', image: 'usp-darkwater.png', rarity: 'common' },
+  { name: 'AK-47 | Redline', image: 'ak-redline.png', rarity: 'rare' },
+  { name: 'AWP | Asiimov', image: 'awp-asiimov.png', rarity: 'epic' },
+  { name: 'M4A1-S | Knight', image: 'm4a1s-knight.png', rarity: 'legendary' }
+];
+
+const dropTable = [
+  { rarity: 'common', weight: 60 },
+  { rarity: 'rare', weight: 25 },
+  { rarity: 'epic', weight: 10 },
+  { rarity: 'legendary', weight: 5 }
+];
+
+function getRandomSkin() {
+  const rand = Math.random() * 100;
+  let cumulative = 0;
+  let selectedRarity = dropTable[0].rarity;
+  for (const entry of dropTable) {
+    cumulative += entry.weight;
+    if (rand < cumulative) {
+      selectedRarity = entry.rarity;
+      break;
+    }
+  }
+  const choices = skins.filter(s => s.rarity === selectedRarity);
+  return choices[Math.floor(Math.random() * choices.length)];
+}
+
+module.exports = getRandomSkin;


### PR DESCRIPTION
## Summary
- add drop table utility for skin chances
- integrate drop table in `openCase` controller

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68765a3b0eb4832b86a61fd18ca515db